### PR TITLE
Title Toggle

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2861,4 +2861,5 @@
 #include "maps\submaps\planetary_ruins\radshrine\radshrine.dm"
 #include "maps\submaps\planetary_ruins\spider_nest\spider_nest.dm"
 #include "maps\submaps\planetary_ruins\tar_anomaly\tar_anomaly.dm"
+#include "zzzz_modular_equinox\code\modules\mob\living\carbon\human\human.dm"
 // END_INCLUDE

--- a/zzzz_modular_equinox/code/modules/mob/living/carbon/human/human.dm
+++ b/zzzz_modular_equinox/code/modules/mob/living/carbon/human/human.dm
@@ -1,0 +1,15 @@
+/mob/living/carbon/human
+	var/show_title = TRUE
+
+/mob/living/carbon/human/get_id_rank()
+	. = ..()
+	if(show_title == FALSE)
+		return ""
+
+//this module toggles between showing job title on the entity's name
+/mob/living/carbon/human/verb/toggle_title()
+	set name = "Toggle Title"
+	set desc = "Shows or hides your title."
+	set category = "IC"
+	show_title = !show_title
+	to_chat(usr, "You change your mind about showing your title.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows for special job title roles to toggle the visibility of their title in front of their name.

Example: Doctor Einholve -> Scarlet Einholve and back

## Why It's Good For The Game

Allows characters to customize their name for roleplay situations without requiring hiding the ID. 

## Testing

The code compiled with no errors, mobs can switch their title back and forth and the message display is working correctly.

## Changelog
:cl:
add: Add the ability to toggle title on and off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
